### PR TITLE
Fix Fifo issue.

### DIFF
--- a/SPI.h
+++ b/SPI.h
@@ -469,6 +469,7 @@ public:
 			SPI0_CTAR1 = settings.ctar| SPI_CTAR_FMSZ(8);
 			SPI0_MCR = SPI_MCR_MSTR | SPI_MCR_PCSIS(0x1F);
 		}
+		SPI0_MCR |= SPI_MCR_CLR_TXF | SPI_MCR_CLR_RXF;
 	}
 
 	// Write to the SPI bus (MOSI pin) and also receive (MISO pin)


### PR DESCRIPTION
There is an issue where with some SPI devices (ILI9341_t3) when they
finish a transaction, the receive fifo may not be empty, which causes
simple SPI.transfer to return the wrong data.

This fix is to empty the fifos each time we begin a transaction.
More details in the thread:

https://forum.pjrc.com/threads/26305-Highly-optimized-ILI9341-%28320x240-TFT-color-display%29-library?p=71210&viewfull=1#post71210