### PR TITLE
Allow setMISO/setMOSI/setSCK - after begin

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -421,6 +421,13 @@ void SPIClass::setMOSI(uint8_t pin)
 	if (pin != hardware().mosi_pin[mosi_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().mosi_pin); i++) {
 			if  (pin == hardware().mosi_pin[i]) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().mosi_pin[mosi_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().mosi_pin[i]);
+					*reg = hardware().mosi_mux[i];
+				}	
 				mosi_pin_index = i;
 				return;
 			}
@@ -433,6 +440,13 @@ void SPIClass::setMISO(uint8_t pin)
 	if (pin != hardware().miso_pin[miso_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().miso_pin); i++) {
 			if  (pin == hardware().miso_pin[i]) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().miso_pin[miso_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().miso_pin[i]);
+					*reg = hardware().miso_mux[i];
+				}	
 				miso_pin_index = i;
 				return;
 			}
@@ -445,6 +459,13 @@ void SPIClass::setSCK(uint8_t pin)
 	if (pin != hardware().sck_pin[sck_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().sck_pin); i++) {
 			if  (pin == hardware().sck_pin[i]) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().sck_pin[sck_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().sck_pin[i]);
+					*reg = hardware().sck_mux[i];
+				}	
 				sck_pin_index = i;
 				return;
 			}
@@ -634,6 +655,13 @@ void SPIClass::setMOSI(uint8_t pin)
 	if (pin != hardware().mosi_pin[mosi_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().mosi_pin); i++) {
 			if (pin == hardware().mosi_pin[i] ) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().mosi_pin[mosi_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().mosi_pin[i]);
+					*reg = hardware().mosi_mux[i];
+				}	
 				mosi_pin_index = i;
 				return;
 			}
@@ -646,6 +674,13 @@ void SPIClass::setMISO(uint8_t pin)
 	if (pin != hardware().miso_pin[miso_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().miso_pin); i++) {
 			if (pin == hardware().miso_pin[i] ) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().miso_pin[miso_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().miso_pin[i]);
+					*reg = hardware().miso_mux[i];
+				}	
 				miso_pin_index = i;
 				return;
 			}
@@ -658,6 +693,13 @@ void SPIClass::setSCK(uint8_t pin)
 	if (pin != hardware().sck_pin[sck_pin_index]) {
 		for (unsigned int i = 0; i < sizeof(hardware().sck_pin); i++) {
 			if (pin == hardware().sck_pin[i] ) {
+				if (hardware().clock_gate_register & hardware().clock_gate_mask) {
+					volatile uint32_t *reg;
+					reg = portConfigRegister(hardware().sck_pin[sck_pin_index]);
+					*reg = 0;
+					reg = portConfigRegister(hardware().sck_pin[i]);
+					*reg = hardware().sck_mux[i];
+				}	
 				sck_pin_index = i;
 				return;
 			}


### PR DESCRIPTION
Made the SPI code work like the old stuff where you could set the miso/mosi/sck pins after the begin.

Some people actually used this for changing SPI on the fly to use multiple sets of pins

Tested with simple app on T3.6

```
#include <SPI.h>

void setup() {
  while (!Serial && (millis() < 3000)) ;
  Serial.begin(9600);
  Serial.println("SPI Test");

  SPI.begin();
  SPI.setMOSI(7);
  SPI.setMISO(8);
  SPI.setSCK(14);
}

void loop() {
  SPI.beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE0));
  int errors = 0;
  for (int i=0; i < 10; i++) {
    int j = SPI.transfer(i);
    if (i != j) {
      Serial.printf("Mismatch %d != %d\n", i, j);
      errors = 1;
    }
  }
  if (errors == 0) 
    Serial.println("No Errors");
  SPI.endTransaction();
  delay(2000);

}
```
I verified without a jumper between 7 and 8 and looked at Logic analyzer and then put in jumper between 7 and 8. 
