### PR TITLE
Example setup code bug

### DIFF
--- a/examples/DigitalPotControl/DigitalPotControl.ino
+++ b/examples/DigitalPotControl/DigitalPotControl.ino
@@ -37,7 +37,7 @@ const int slaveSelectPin = 10;
 void setup() {
   // set the slaveSelectPin as an output:
   pinMode (slaveSelectPin, OUTPUT);
-  pinMode (slaveSelectPin, HIGH);
+  digitalWrite (slaveSelectPin, HIGH);
   // initialize SPI:
   SPI.begin(); 
 }


### PR DESCRIPTION
The code was doing:
pinMode(slaveSelectPin, OUTPUT);
pinMode(slaveSelectPin, HIGH);

Second pinMode should be digitalWrite