### PR TITLE
T3.5/6 Pin 45 is valid CS

### DIFF
--- a/SPI.h
+++ b/SPI.h
@@ -520,10 +520,10 @@ public:
 		inTransactionFlag = 1;
 		#endif
 		if (port().CTAR0 != settings.ctar) {
-			port().MCR = SPI_MCR_MDIS | SPI_MCR_HALT | SPI_MCR_PCSIS(0x1F);
+			port().MCR = SPI_MCR_MDIS | SPI_MCR_HALT | SPI_MCR_PCSIS(0x3F);
 			port().CTAR0 = settings.ctar;
 			port().CTAR1 = settings.ctar| SPI_CTAR_FMSZ(8);
-			port().MCR = SPI_MCR_MSTR | SPI_MCR_PCSIS(0x1F);
+			port().MCR = SPI_MCR_MSTR | SPI_MCR_PCSIS(0x3F);
 		}
 	}
 


### PR DESCRIPTION
but it is CS5 which encodes to 0x20 and our
macros only handled up to 0x1f... so changed
to 0x3f.

Tested on my ILI9341_t3n test now works with DC on 45... Needs change in Core as well