### PR TITLE
Update SPI.h

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -760,7 +760,7 @@ bool SPIClass::initDMAChannels() {
 }
 
 //=========================================================================
-// Main Aync Transfer function
+// Main Async Transfer function
 //=========================================================================
 
 bool SPIClass::transfer(const void *buf, void *retbuf, size_t count, EventResponderRef event_responder) {
@@ -1194,7 +1194,7 @@ bool SPIClass::initDMAChannels() {
 }
 
 //=========================================================================
-// Main Aync Transfer function
+// Main Async Transfer function
 //=========================================================================
 bool SPIClass::transfer(const void *buf, void *retbuf, size_t count, EventResponderRef event_responder) {
 	if (_dma_state == DMAState::notAllocated) {

--- a/SPI.h
+++ b/SPI.h
@@ -540,12 +540,16 @@ public:
 		while (!(port().SR & SPI_SR_TCF)) ; // wait
 		return port().POPR;
 	}
-        void transfer16(uint16_t *data, int len) {
-                for ( uint16_t i = 0; i < len; i++ ) {
-                  port().SR = SPI_SR_TCF;
-                  port().PUSHR = data[i] | SPI_PUSHR_CTAS(1);
-                  while (!(port().SR & SPI_SR_TCF)) ; // wait
-                }
+        void transfer16(const void * buf, void * retbuf, size_t count) {
+          if ( !count ) return;
+          const uint16_t *b = (const uint16_t *)buf;
+          uint16_t *r = (uint16_t *)retbuf;
+          for ( uint16_t i = 0; i < count; i++ ) {
+            port().SR = SPI_SR_TCF;
+            port().PUSHR = b[i] | SPI_PUSHR_CTAS(1);
+            while (!(port().SR & SPI_SR_TCF)) ; // wait
+            if ( r ) r[i] = port().POPR;
+          }
         }
 
 	void inline transfer(void *buf, size_t count) {transfer(buf, buf, count);}

--- a/SPI.h
+++ b/SPI.h
@@ -540,6 +540,13 @@ public:
 		while (!(port().SR & SPI_SR_TCF)) ; // wait
 		return port().POPR;
 	}
+        void transfer16(uint16_t *data, int len) {
+                for ( uint16_t i = 0; i < len; i++ ) {
+                  port().SR = SPI_SR_TCF;
+                  port().PUSHR = data[i] | SPI_PUSHR_CTAS(1);
+                  while (!(port().SR & SPI_SR_TCF)) ; // wait
+                }
+        }
 
 	void inline transfer(void *buf, size_t count) {transfer(buf, buf, count);}
 	void setTransferWriteFill(uint8_t ch ) {_transferWriteFill = ch;}


### PR DESCRIPTION
Support sending 16bit arrays without changing endianness of dwords

The current buffer writes are 8bit and when casting using that transfer(buffer,len) function the byte order is swapped
The above method sends the dwords exactly as they are into the 16bit PUSHR register