### PR TITLE
Added dummy end() function to SPI.ccp

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1463,7 +1463,7 @@ void SPIClass::transfer(const void * buf, void * retbuf, size_t count)
 }
 
 
-
+void SPIClass::end(){}
 
 
 


### PR DESCRIPTION
During compile of the Radiohead library received an undefined reference to SPIclass::end().   Added a dummy end() function to the SPI.cpp file for compatibility.