### PR TITLE
T4 b2 spi1 spi2

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1400,6 +1400,42 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi4_hardware = {
 	3 | 0x10,
 };
 SPIClass SPI((uintptr_t)&IMXRT_LPSPI4_S, (uintptr_t)&SPIClass::spiclass_lpspi4_hardware);
+
+#if defined(__IMXRT1062__)
+// T4 has two other possible SPI objects...
+void _spi_dma_rxISR1(void) {SPI1.dma_rxisr();}
+
+const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi3_hardware = {
+	CCM_CCGR1, CCM_CCGR1_LPSPI3(CCM_CCGR_ON),
+	DMAMUX_SOURCE_LPSPI3_TX, DMAMUX_SOURCE_LPSPI3_RX, _spi_dma_rxISR1,
+	1, 
+	7 | 0x10,
+	26,
+	7 | 0x10,
+	27,
+	7 | 0x10,
+	0,
+	7 | 0x10,
+};
+SPIClass SPI1((uintptr_t)&IMXRT_LPSPI3_S, (uintptr_t)&SPIClass::spiclass_lpspi3_hardware);
+
+void _spi_dma_rxISR2(void) {SPI2.dma_rxisr();}
+
+const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi1_hardware = {
+	CCM_CCGR1, CCM_CCGR1_LPSPI1(CCM_CCGR_ON),
+	DMAMUX_SOURCE_LPSPI1_TX, DMAMUX_SOURCE_LPSPI1_RX, _spi_dma_rxISR1,
+	34, 
+	4 | 0x10,
+	35,
+	4 | 0x10,
+	37,
+	4 | 0x10,
+	36,
+	4 | 0x10,
+};
+SPIClass SPI2((uintptr_t)&IMXRT_LPSPI1_S, (uintptr_t)&SPIClass::spiclass_lpspi1_hardware);
+#endif
+
 //SPIClass SPI(&IMXRT_LPSPI4_S, &spiclass_lpspi4_hardware);
 
 void SPIClass::usingInterrupt(IRQ_NUMBER_t interruptName)

--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1293,6 +1293,12 @@ void SPIClass::begin()
 	*(portConfigRegister(hardware().mosi_pin [mosi_pin_index])) = hardware().mosi_mux[mosi_pin_index];
 	*(portConfigRegister(hardware().sck_pin [sck_pin_index])) = hardware().sck_mux[sck_pin_index];
 
+	// Set the Mux pins 
+	//Serial.println("SPI: Set Input select registers");
+	hardware().sck_select_input_register = hardware().sck_select_val;
+	hardware().sdi_select_input_register = hardware().sdi_select_val;
+	hardware().sdo_select_input_register = hardware().sdo_select_val;
+
 	//digitalWriteFast(10, HIGH);
 	//pinMode(10, OUTPUT);
 	//digitalWriteFast(10, HIGH);
@@ -1398,7 +1404,11 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi4_hardware = {
 	3 | 0x10,
 	10,
 	3 | 0x10,
+	IOMUXC_LPSPI4_SCK_SELECT_INPUT, IOMUXC_LPSPI4_SDI_SELECT_INPUT, IOMUXC_LPSPI4_SDO_SELECT_INPUT, IOMUXC_LPSPI4_PCS0_SELECT_INPUT,
+	0, 0, 0, 0
 };
+
+
 SPIClass SPI((uintptr_t)&IMXRT_LPSPI4_S, (uintptr_t)&SPIClass::spiclass_lpspi4_hardware);
 
 #if defined(__IMXRT1062__)
@@ -1416,6 +1426,8 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi3_hardware = {
 	7 | 0x10,
 	0,
 	7 | 0x10,
+	IOMUXC_LPSPI3_SCK_SELECT_INPUT, IOMUXC_LPSPI3_SDI_SELECT_INPUT, IOMUXC_LPSPI3_SDO_SELECT_INPUT, IOMUXC_LPSPI3_PCS0_SELECT_INPUT,
+	1, 1, 0, 0
 };
 SPIClass SPI1((uintptr_t)&IMXRT_LPSPI3_S, (uintptr_t)&SPIClass::spiclass_lpspi3_hardware);
 
@@ -1432,6 +1444,8 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi1_hardware = {
 	4 | 0x10,
 	36,
 	4 | 0x10,
+	IOMUXC_LPSPI1_SCK_SELECT_INPUT, IOMUXC_LPSPI1_SDI_SELECT_INPUT, IOMUXC_LPSPI1_SDO_SELECT_INPUT, IOMUXC_LPSPI1_PCS0_SELECT_INPUT,
+	1, 1, 1, 0
 };
 SPIClass SPI2((uintptr_t)&IMXRT_LPSPI1_S, (uintptr_t)&SPIClass::spiclass_lpspi1_hardware);
 #endif

--- a/SPI.h
+++ b/SPI.h
@@ -1111,6 +1111,15 @@ public:
 		const uint32_t  sck_mux[CNT_SCK_PINS];
 		const uint8_t  cs_pin[CNT_CS_PINS];
 		const uint32_t  cs_mux[CNT_CS_PINS];
+
+		volatile uint32_t &sck_select_input_register;
+		volatile uint32_t &sdi_select_input_register;
+		volatile uint32_t &sdo_select_input_register;
+		volatile uint32_t &pcs0_select_input_register;
+		const uint8_t sck_select_val;
+		const uint8_t sdi_select_val;
+		const uint8_t sdo_select_val;
+		const uint8_t pcs0_select_val;
 	} SPI_Hardware_t;
 	static const SPI_Hardware_t spiclass_lpspi4_hardware;
 #if defined(__IMXRT1062__)

--- a/SPI.h
+++ b/SPI.h
@@ -1113,7 +1113,10 @@ public:
 		const uint32_t  cs_mux[CNT_CS_PINS];
 	} SPI_Hardware_t;
 	static const SPI_Hardware_t spiclass_lpspi4_hardware;
-
+#if defined(__IMXRT1062__)
+	static const SPI_Hardware_t spiclass_lpspi3_hardware;
+	static const SPI_Hardware_t spiclass_lpspi1_hardware;
+#endif	
 public:
 	constexpr SPIClass(uintptr_t myport, uintptr_t myhardware)
 		: port_addr(myport), hardware_addr(myhardware) {
@@ -1362,7 +1365,7 @@ extern SPIClass SPI;
 #if defined(__MKL26Z64__)
 extern SPIClass SPI1;
 #endif
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__IMXRT1062__)
 extern SPIClass SPI1;
 extern SPIClass SPI2;
 #endif


### PR DESCRIPTION
Create SPI1 and SPI2 for Teensy4 Beta 2 board.

SPI1 uses the bottom mount pins (not tested yet)
SPI2 uses the pins I created in
https://github.com/PaulStoffregen/cores/pull/366
For the 6 signals that are associated with SDCard. 

I test running our ILI9488_t3 library that we are working on with B2 board
using Sparkfun SD Card breakout board. 