### PR TITLE
T4 Pin configuration.

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1280,7 +1280,7 @@ void SPIClass::begin()
 	CCM_CBCMR = (CCM_CBCMR & ~(CCM_CBCMR_LPSPI_PODF_MASK | CCM_CBCMR_LPSPI_CLK_SEL_MASK)) |
 		CCM_CBCMR_LPSPI_PODF(6) | CCM_CBCMR_LPSPI_CLK_SEL(2); // pg 714
 
-	uint32_t fastio = IOMUXC_PAD_SRE | IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
+	uint32_t fastio = IOMUXC_PAD_DSE(6) | IOMUXC_PAD_SPEED(1);
 	//uint32_t fastio = IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
 	//Serial.printf("SPI MISO: %d MOSI: %d, SCK: %d\n", hardware().miso_pin[miso_pin_index], hardware().mosi_pin[mosi_pin_index], hardware().sck_pin[sck_pin_index]);
 	*(portControlRegister(hardware().miso_pin[miso_pin_index])) = fastio;


### PR DESCRIPTION
There have been some issues with SCK pins and the like not appearing to work as well as on T3.x...

We have been experiementing with changing the DSE and SPEED value and this has helped in some cases.

@PaulStoffregen - You might see if this is the best configuration settings for this or if you might suggest something different