### PR TITLE
T4: Support legacy (pre SPI.transaction) methods

### DIFF
--- a/SPI.h
+++ b/SPI.h
@@ -1283,19 +1283,19 @@ public:
 	// beginTransaction() to configure SPI settings.
 	void setClockDivider(uint8_t clockDiv) {
 		if (clockDiv == SPI_CLOCK_DIV2) {
-			//setClockDivider_noInline(SPISettings(12000000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(12000000);
 		} else if (clockDiv == SPI_CLOCK_DIV4) {
-			//setClockDivider_noInline(SPISettings(4000000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(4000000);
 		} else if (clockDiv == SPI_CLOCK_DIV8) {
-			//setClockDivider_noInline(SPISettings(2000000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(2000000);
 		} else if (clockDiv == SPI_CLOCK_DIV16) {
-			//setClockDivider_noInline(SPISettings(1000000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(1000000);
 		} else if (clockDiv == SPI_CLOCK_DIV32) {
-			//setClockDivider_noInline(SPISettings(500000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(500000);
 		} else if (clockDiv == SPI_CLOCK_DIV64) {
-			//setClockDivider_noInline(SPISettings(250000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(250000);
 		} else { /* clockDiv == SPI_CLOCK_DIV128 */
-			//setClockDivider_noInline(SPISettings(125000, MSBFIRST, SPI_MODE0).ctar);
+			setClockDivider_noInline(125000);
 		}
 	}
 	void setClockDivider_noInline(uint32_t clk);


### PR DESCRIPTION
The code would fail if the user did an SPI.transfer without calling SPI.beginTransaction.

So begin now calls beginTransaction with default parameters.

Also put in an implemention for SPI.setClockDivider as well as SPI.setDataMode

They appear to work OK...  Tried to do with out changing any of the current functionality other than to call begin/end transaction in begin to get to a stable state.