### PR TITLE
T4 - Default allow faster speeds...

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1278,9 +1278,11 @@ void SPIClass::begin()
 	hardware().clock_gate_register &= ~hardware().clock_gate_mask;
 
 	CCM_CBCMR = (CCM_CBCMR & ~(CCM_CBCMR_LPSPI_PODF_MASK | CCM_CBCMR_LPSPI_CLK_SEL_MASK)) |
-		CCM_CBCMR_LPSPI_PODF(6) | CCM_CBCMR_LPSPI_CLK_SEL(2); // pg 714
+		CCM_CBCMR_LPSPI_PODF(2) | CCM_CBCMR_LPSPI_CLK_SEL(1); // pg 714
+//		CCM_CBCMR_LPSPI_PODF(6) | CCM_CBCMR_LPSPI_CLK_SEL(2); // pg 714
 
-	uint32_t fastio = IOMUXC_PAD_DSE(6) | IOMUXC_PAD_SPEED(1);
+	uint32_t fastio = IOMUXC_PAD_DSE(7) | IOMUXC_PAD_SPEED(2);
+	//uint32_t fastio = IOMUXC_PAD_DSE(6) | IOMUXC_PAD_SPEED(1);
 	//uint32_t fastio = IOMUXC_PAD_DSE(3) | IOMUXC_PAD_SPEED(3);
 	//Serial.printf("SPI MISO: %d MOSI: %d, SCK: %d\n", hardware().miso_pin[miso_pin_index], hardware().mosi_pin[mosi_pin_index], hardware().sck_pin[sck_pin_index]);
 	*(portControlRegister(hardware().miso_pin[miso_pin_index])) = fastio;


### PR DESCRIPTION
I changed the Clock that was used and settings.
So I think maximum speed changed from about 37+mhz to 60mhz

I was haing issues at 60mhz with simple test so also changed the IO ins Speed and DSE values which appeared to work.

I tried running our ILI9488_t3 library at 60mhz and it appears to work :D

More details up on the thread: https://forum.pjrc.com/threads/57652-Teensy-4-SPI-bus-gt-38mhz-possible

@PaulStoffregen  - As I mentioned on the thread, The few things I have been wondering with is the trade off of allowing faster speeds against the ability to run SPI at low speeds. 
A quote from that thread:

> I would suspect with current settings of 240 mhz as the raw clock (after initial divisor), and the clocks work by dividing by some register value (plus 2).
> 
> That the valid speeds are (120mhz, 80mhz, 60mhz, 48, 40, 34.29, 30mhz, 26.67, 24mhz, ..., I believe the slowest is about 934K.
> 
> Question will be is this slow enough? The current released clock gets us down to maybe 293KB.
> 
> Of course we could make this more configurable, that if the user asks for something slower than we can give, we could reconfigure the clock. Would maybe need to then hack it up that any other SPI busses that had already calculated SPI register value for speed would recompute on the next SPIx.beginTransaction... 

Now I don't think in most cases 120mhz will work, but I configured it that way as in some cases 80mhz works and in most 60mhz works... So 240mhz (min divisor of 2) appeared like an interesting thing to try..., 

But could back off and for example change divisor (PODF) field from 2 to 5 which would change the I2C clock from 240mhz to 120mhz so top speed of 60mhz which is sort of highest speed we could get on T3.6 I think, which drops the minimum speed down to 467khz... 

Thoughts?