### PR TITLE
T4.1 - Pins different than T4.0 and SPI2

### DIFF
--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1394,7 +1394,8 @@ uint8_t SPIClass::setCS(uint8_t pin)
 {
 	for (unsigned int i = 0; i < sizeof(hardware().cs_pin); i++) {
 		if (pin == hardware().cs_pin[i]) {
-			*(portConfigRegister(pin)) = hardware().sck_mux[i];
+			*(portConfigRegister(pin)) = hardware().cs_mux[i];
+			hardware().pcs0_select_input_register = hardware().pcs0_select_val[i];
 			return 1;
 		}
 	}

--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1341,7 +1341,7 @@ void SPIClass::setClockDivider_noInline(uint32_t clk) {
 			div =0;
 		}
 
-		_ccr = LPSPI_CCR_SCKDIV(div) | LPSPI_CCR_DBT(div/2);
+		_ccr = LPSPI_CCR_SCKDIV(div) | LPSPI_CCR_DBT(div/2) | LPSPI_CCR_PCSSCK(div/2);
 
 	} 
 	//Serial.printf("SPI.setClockDivider_noInline CCR:%x TCR:%x\n", _ccr, port().TCR);
@@ -1519,7 +1519,7 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi4_hardware = {
 	IOMUXC_LPSPI4_SCK_SELECT_INPUT,
 	10, 37, 36, // CS
 	3 | 0x10, 2 | 0x10, 2 | 0x10, 
-	1, 0x2, 0x4,
+	1, 2, 3,
 	0, 0, 0,
 	&IOMUXC_LPSPI4_PCS0_SELECT_INPUT, 0, 0
 };

--- a/SPI.cpp
+++ b/SPI.cpp
@@ -1492,6 +1492,16 @@ void _spi_dma_rxISR2(void) {SPI2.dma_rxisr();}
 const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi1_hardware = {
 	CCM_CCGR1, CCM_CCGR1_LPSPI1(CCM_CCGR_ON),
 	DMAMUX_SOURCE_LPSPI1_TX, DMAMUX_SOURCE_LPSPI1_RX, _spi_dma_rxISR1,
+	#if defined(ARDUINO_TEENSY41)
+	42, 
+	4 | 0x10,
+	43,
+	4 | 0x10,
+	45,
+	4 | 0x10,
+	44,
+	4 | 0x10,
+	#else
 	34, 
 	4 | 0x10,
 	35,
@@ -1500,6 +1510,7 @@ const SPIClass::SPI_Hardware_t  SPIClass::spiclass_lpspi1_hardware = {
 	4 | 0x10,
 	36,
 	4 | 0x10,
+#endif	
 	IOMUXC_LPSPI1_SCK_SELECT_INPUT, IOMUXC_LPSPI1_SDI_SELECT_INPUT, IOMUXC_LPSPI1_SDO_SELECT_INPUT, IOMUXC_LPSPI1_PCS0_SELECT_INPUT,
 	1, 1, 1, 0
 };

--- a/SPI.h
+++ b/SPI.h
@@ -1073,7 +1073,7 @@ public:
 	static const uint8_t CNT_MISO_PINS = 2;
 	static const uint8_t CNT_MOSI_PINS = 2;
 	static const uint8_t CNT_SCK_PINS = 2;
-	static const uint8_t CNT_CS_PINS = 1;
+	static const uint8_t CNT_CS_PINS = 3;
 	#else
 	static const uint8_t CNT_MISO_PINS = 1;
 	static const uint8_t CNT_MOSI_PINS = 1;
@@ -1107,8 +1107,9 @@ public:
 		// CS Pins
 		const uint8_t  		cs_pin[CNT_CS_PINS];
 		const uint32_t  	cs_mux[CNT_CS_PINS];
-		const uint8_t 		pcs0_select_val[CNT_CS_PINS];
-		volatile uint32_t 	&pcs0_select_input_register;
+		const uint8_t  		cs_mask[CNT_CS_PINS];
+		const uint8_t 		pcs_select_val[CNT_CS_PINS];
+		volatile uint32_t 	*pcs_select_input_register[CNT_CS_PINS];
 
 	} SPI_Hardware_t;
 	static const SPI_Hardware_t spiclass_lpspi4_hardware;

--- a/SPI.h
+++ b/SPI.h
@@ -1068,33 +1068,48 @@ private:
 
 class SPIClass { // Teensy 4
 public:
+	#if defined(ARDUINO_TEENSY41)
+	// T4.1 has SPI2 pins on memory connectors as well as SDCard
+	static const uint8_t CNT_MISO_PINS = 2;
+	static const uint8_t CNT_MOSI_PINS = 2;
+	static const uint8_t CNT_SCK_PINS = 2;
+	static const uint8_t CNT_CS_PINS = 1;
+	#else
 	static const uint8_t CNT_MISO_PINS = 1;
 	static const uint8_t CNT_MOSI_PINS = 1;
 	static const uint8_t CNT_SCK_PINS = 1;
 	static const uint8_t CNT_CS_PINS = 1;
+#endif
 	typedef struct {
 		volatile uint32_t &clock_gate_register;
 		const uint32_t clock_gate_mask;
 		uint8_t  tx_dma_channel;
 		uint8_t  rx_dma_channel;
 		void     (*dma_rxisr)();
-		const uint8_t  miso_pin[CNT_MISO_PINS];
-		const uint32_t  miso_mux[CNT_MISO_PINS];
-		const uint8_t  mosi_pin[CNT_MOSI_PINS];
-		const uint32_t  mosi_mux[CNT_MOSI_PINS];
-		const uint8_t  sck_pin[CNT_SCK_PINS];
-		const uint32_t  sck_mux[CNT_SCK_PINS];
-		const uint8_t  cs_pin[CNT_CS_PINS];
-		const uint32_t  cs_mux[CNT_CS_PINS];
+		// MISO pins
+		const uint8_t  		miso_pin[CNT_MISO_PINS];
+		const uint32_t  	miso_mux[CNT_MISO_PINS];
+		const uint8_t 		miso_select_val[CNT_MISO_PINS];
+		volatile uint32_t 	&miso_select_input_register;
 
-		volatile uint32_t &sck_select_input_register;
-		volatile uint32_t &sdi_select_input_register;
-		volatile uint32_t &sdo_select_input_register;
-		volatile uint32_t &pcs0_select_input_register;
-		const uint8_t sck_select_val;
-		const uint8_t sdi_select_val;
-		const uint8_t sdo_select_val;
-		const uint8_t pcs0_select_val;
+		// MOSI pins
+		const uint8_t  		mosi_pin[CNT_MOSI_PINS];
+		const uint32_t  	mosi_mux[CNT_MOSI_PINS];
+		const uint8_t 		mosi_select_val[CNT_MOSI_PINS];
+		volatile uint32_t 	&mosi_select_input_register;
+
+		// SCK pins
+		const uint8_t  		sck_pin[CNT_SCK_PINS];
+		const uint32_t  	sck_mux[CNT_SCK_PINS];
+		const uint8_t 		sck_select_val[CNT_SCK_PINS];
+		volatile uint32_t 	&sck_select_input_register;
+
+		// CS Pins
+		const uint8_t  		cs_pin[CNT_CS_PINS];
+		const uint32_t  	cs_mux[CNT_CS_PINS];
+		const uint8_t 		pcs0_select_val[CNT_CS_PINS];
+		volatile uint32_t 	&pcs0_select_input_register;
+
 	} SPI_Hardware_t;
 	static const SPI_Hardware_t spiclass_lpspi4_hardware;
 #if defined(__IMXRT1062__)

--- a/SPI.h
+++ b/SPI.h
@@ -1221,7 +1221,7 @@ public:
 				div =0;
 			}
 	
-			_ccr = LPSPI_CCR_SCKDIV(div) | LPSPI_CCR_DBT(div/2);
+			_ccr = LPSPI_CCR_SCKDIV(div) | LPSPI_CCR_DBT(div/2) | LPSPI_CCR_PCSSCK(div/2);
 
 		} 
 		//Serial.printf("SPI.beginTransaction CCR:%x TCR:%x\n", _ccr, settings.tcr);


### PR DESCRIPTION
T41 pin numbers are different on SPI2..

Also SPI2 has Pin numbers both on SDCard pins as well as bottom memory pins, 
so setMOSI, setMISO, setSCK was implemented for T4 and T4.1... 

Did quick test on one display on T4 for SPI and SPI1

Did quck tests on another display on T4.1 with SPI and SPI1 and different display for SPI2