### PR TITLE
Add #define SPI_HAS_NOTUSINGINTERRUPT where missing

### DIFF
--- a/SPI.h
+++ b/SPI.h
@@ -681,6 +681,8 @@ private:
 /**********************************************************/
 
 #elif defined(__arm__) && defined(TEENSYDUINO) && defined(KINETISL)
+
+#define SPI_HAS_NOTUSINGINTERRUPT 1
 #define SPI_ATOMIC_VERSION 1
 
 class SPISettings {
@@ -1029,6 +1031,8 @@ private:
 /**********************************************************/
 
 #elif defined(__arm__) && defined(TEENSYDUINO) && (defined(__IMXRT1052__) || defined(__IMXRT1062__))
+
+#define SPI_HAS_NOTUSINGINTERRUPT 1
 #define SPI_ATOMIC_VERSION 1
 
 //#include "debug/printf.h"


### PR DESCRIPTION
This is **_vital_** for the audio library, as otherwise at _any_ time after an audio file has been played from SPI-based SD, _any_ SPI access _at all_ will mask audio interrupts, even if file playback is not currently going on.